### PR TITLE
RHMAP-13988 SAML Cordova template has errors and doesn't work on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If you wish to contribute to this template, the following information may be hel
 ## Build instructions
  * npm install
  * Edit [fhconfig.json](www/fhconfig.json) to include the relevant information from RHMAP.  
+ * Edit [config.xml](config.xml) to add an access tag for the SAML_ENTRY_POINT from RHMAP.
  * cordova serve  
 
 ### npm dependencies

--- a/config.xml
+++ b/config.xml
@@ -6,8 +6,8 @@
     </description>
     <content src="index.html" />
     <access origin="*" />
-    <engine name="android" spec="4.1.0" />
-    <engine name="ios" spec="3.9.0" />
+    <engine name="android" />
+    <engine name="ios" />
     <preference name="fullscreen" value="true" />
     <preference name="webviewbounce" value="true" />
     <plugin name="cordova-plugin-whitelist" spec="https://github.com/apache/cordova-plugin-whitelist.git#rel/1.2.2" />

--- a/www/index.html
+++ b/www/index.html
@@ -3,7 +3,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 
-  <meta http-equiv="Content-Security-Policy" content="default-src *; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'">
+  <meta http-equiv="Content-Security-Policy" content="default-src * gap:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'">
 
   <title>SAML Client Example</title>
 


### PR DESCRIPTION
Cherry pick

Removed the spec from platforms so it uses the pinned by the CLI
Added gap: to the CSP so Cordova Plugins work on iOS 10
Added a step to build instructions to add an access tag for the SAML_ENTRY_POINT, will also be documented on the SAML guide.